### PR TITLE
perf: output should flush at the end instead of every newline

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -1,3 +1,4 @@
+use std::io::{self};
 use std::{fs, path::PathBuf, process::exit};
 
 use owo_colors::OwoColorize;
@@ -80,5 +81,8 @@ fn print_styled_table(mut table: Table, has_line_numbers: bool) {
     table.modify(Columns::one(col_index), Color::FG_BRIGHT_GREEN); // Modified Date
 
     table.modify(Rows::first(), Color::FG_BRIGHT_GREEN);
-    println!("{}", table);
+    let stdout = io::stdout();
+    let mut stdout_lock = stdout.lock();
+    writeln!(stdout_lock, "{}", table).unwrap();
+    stdout_lock.flush().unwrap();
 }

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -53,7 +53,7 @@ pub fn get_files_from_directories(
     }
 
     for dir_path in directories_to_scan {
-        let mut dir_entries = get_file_from_single_directory(
+        let dir_entries = get_file_from_single_directory(
             &dir_path,
             pattern,
             re_grab_pattern,


### PR DESCRIPTION
this isn't major perf improvement, but we're trying to squeeze every last bit of perf since iyanls is really slow compared to gnu ls